### PR TITLE
riscv64 build against locally built besu-native and rocksdbjni

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,9 @@ licenseReport {
     'org.checkerframework:dataflow-errorprone',
     // exclude Kotlin multiplatform dependencies container, they have the same license of what they contain
     'com.squareup.okio:okio',
-    'org.jetbrains.kotlinx:kotlinx-coroutines-core'
+    'org.jetbrains.kotlinx:kotlinx-coroutines-core',
+    // Temporarily exclude rocksdbjni for local build testing
+    'org.rocksdb:rocksdbjni'
   ]
 
   // If set to true, then all boms will be excluded from the report
@@ -164,6 +166,8 @@ configure(allprojects - project(':platform')) {
       url 'https://splunk.jfrog.io/splunk/ext-releases-local'
       content { includeGroupByRegex('com\\.splunk\\..*') }
     }
+
+    mavenLocal()
 
     mavenCentral()
 

--- a/ethereum/core/build.gradle
+++ b/ethereum/core/build.gradle
@@ -64,6 +64,7 @@ dependencies {
   implementation 'io.tmio:tuweni-rlp'
   implementation 'org.immutables:value-annotations'
   implementation 'io.consensys.protocols:jc-kzg-4844'
+  implementation 'io.prometheus:simpleclient_guava'
 
   implementation 'org.xerial.snappy:snappy-java'
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.welcome=never
 # versionappendcommit=true
 
 # Optional, skip dependency verification for dev/debug builds
-# org.gradle.dependency.verification=lenient
+org.gradle.dependency.verification=lenient
 
 
 # Set exports/opens flags required by Google Java Format and ErrorProne plugins. (JEP-396)

--- a/platform/build.gradle
+++ b/platform/build.gradle
@@ -31,6 +31,7 @@ dependencies {
   api platform('io.netty:netty-bom:4.1.118.Final')
   api platform('io.opentelemetry:opentelemetry-bom:1.47.0')
   api platform('io.prometheus:prometheus-metrics-bom:1.3.5')
+  api platform('io.prometheus:simpleclient_guava:0.16.0')
   api platform('io.vertx:vertx-stack-depchain:4.5.13')
   api platform('javax.inject:javax.inject:1')
   api platform('org.apache.logging.log4j:log4j-bom:2.24.3')
@@ -138,12 +139,12 @@ dependencies {
 
     api 'org.hibernate.validator:hibernate-validator:8.0.2.Final'
 
-    api 'org.hyperledger.besu:arithmetic:1.1.2'
-    api 'org.hyperledger.besu:blake2bf:1.1.2'
-    api 'org.hyperledger.besu:gnark:1.1.2'
-    api 'org.hyperledger.besu:ipa-multipoint:1.1.2'
-    api 'org.hyperledger.besu:secp256k1:1.1.2'
-    api 'org.hyperledger.besu:secp256r1:1.1.2'
+    api 'org.hyperledger.besu:arithmetic:1.1.3-riscv64'
+    api 'org.hyperledger.besu:blake2bf:1.1.3-riscv64'
+    api 'org.hyperledger.besu:gnark:1.1.3-riscv64'
+    api 'org.hyperledger.besu:ipa-multipoint:1.1.3-riscv64'
+    api 'org.hyperledger.besu:secp256k1:1.1.3-riscv64'
+    api 'org.hyperledger.besu:secp256r1:1.1.3-riscv64'
 
     api 'org.hyperledger.besu:besu-errorprone-checks:1.0.0'
 
@@ -162,7 +163,8 @@ dependencies {
 
     api 'org.owasp.encoder:encoder:1.3.1'
 
-    api 'org.rocksdb:rocksdbjni:9.7.3'
+    //api 'org.rocksdb:rocksdbjni:9.7.3'
+    api 'org.rocksdb:rocksdbjni:9.9.0-linux64'
 
     api 'org.springframework.security:spring-security-crypto:6.4.3'
 
@@ -174,7 +176,7 @@ dependencies {
 
     api 'org.xerial.snappy:snappy-java:1.1.10.7'
 
-    api 'io.consensys.protocols:jc-kzg-4844:2.0.0'
+    api 'io.consensys.protocols:jc-kzg-4844:2.0.1-riscv64'
 
     api 'tech.pegasys.discovery:discovery:25.2.0'
   }


### PR DESCRIPTION
## PR description

This is a placeholder PR to illustrate how to build this branch on linux riscv64:

This is the script I used to build rocksdbjni from [rocksdb](http://github.com/facebook/rocksdb) for riscv64:
```
#!/bin/bash

export CXXFLAGS="-march=rv64gc -latomic"
export LDFLAGS="-latomic"
make clean; make shared_lib DEBUG_LEVEL=0
make rocksdbjava DEBUG_LEVEL=0
mvn install:install-file \
  -Dfile=java/target/rocksdbjni-9.9.0-linux64.jar \
  -DgroupId=org.rocksdb \
  -DartifactId=rocksdbjni \
  -Dversion=9.9.0-linux64 -Dpackaging=jar
```

build a local [besu-native] by checking it out and running `./build.sh && ./gradlew -Pversion=1.1.3-riscv64 build publishToMavenLocal`

finally checkout [this branch](https://github.com/garyschulte/besu/tree/riscv64-build), and run:
`./gradlew distTar` 
